### PR TITLE
Avoid a "panic: runtime error: slice bounds out of range" gracefully

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -113,7 +113,12 @@ func (n NullUUID) MarshalText() ([]byte, error) {
 func (n *NullUUID) UnmarshalJSON(data []byte) error {
 	if bytes.Compare(data, nullByteString) == 0 {
 		n.Valid = false
+		return nil
+	}
 
+	dataLen := len(data)
+	if dataLen < 2 {
+		n.Valid = false
 		return nil
 	}
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -304,6 +304,16 @@ func TestNullUUIDUnmarshalJSON1(t *testing.T) {
 	}
 }
 
+func TestInvalidStringForUUID(t *testing.T) {
+	u := NullUUID{}
+	err := u.UnmarshalJSON([]byte("0"))
+	if err == nil {
+		if u.Valid {
+			t.Error("We should have returned an Invalid UUID")
+		}
+	}
+}
+
 func BenchmarkNullUnmarshalText1(b *testing.B) {
 	n := NullUUID{UUID: UUID{}}
 


### PR DESCRIPTION
Hi there,

I encountered a case where the uuid UnmarshalJSON would panic with a message:
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

This was due to a client sending json in the form:
`json
{
    "uuid":0,
    "something":"a char",
}`

and if we tried to pass this to the json Unmarshal on a struct with a uuid.NullUUID in it tagged as `json:"uuid"` we got a runtime panic.

After some investigation this is because the current Unmarshal implementation make the assumption the incoming data will always be a []byte convertible to string and containing at least 2 double quotes in it (preferably at both ends).

I propose a patch that handles the encountered situation by setting the NullUUID to invalid

I also added a unit test that exhibits the issue on an non patched version.

If you'd like some more testing please let me know. Cheers! And btw thanks for the library!